### PR TITLE
Allow local resolution of adana formatters.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "bl": "^1.0.1",
+    "resolve": "^1.2.0",
     "yargs": "^3.31.0"
   },
   "devDependencies": {

--- a/src/adana.js
+++ b/src/adana.js
@@ -5,13 +5,24 @@
 import yargs from 'yargs';
 import bl from 'bl';
 import { createReadStream } from 'fs';
+import resolve from 'resolve';
 
-function formatter(name) {
-  const module = require(`adana-format-${name}`);
+function _formatter(name) {
+  const module = require(resolve.sync(name, {
+    basedir: process.cwd(),
+  }));
   if (module.__esModule && module.default) {
     return module.default;
   }
   return module;
+}
+
+function formatter(name) {
+  try {
+    return _formatter(`adana-format-${name}`);
+  } catch (err) {
+    return _formatter(name);
+  }
 }
 
 function read({ file }, cb) {


### PR DESCRIPTION
This now works more in line with `babel` and `eslint` and `webpack` where you can specify full paths as well as unprefixed module names.